### PR TITLE
"are" -> "as". Fix word use in spec.

### DIFF
--- a/protocol/RESP2.md
+++ b/protocol/RESP2.md
@@ -190,7 +190,7 @@ RESP Arrays
 
 Clients send commands to the Redis server using RESP Arrays. Similarly
 certain Redis commands returning collections of elements to the client
-use RESP Arrays are reply type. An example is the `LRANGE` command that
+use RESP Arrays as reply type. An example is the `LRANGE` command that
 returns elements of a list.
 
 RESP Arrays are sent using the following format:


### PR DESCRIPTION
Was making a toy Redis server in Java (https://app.codecrafters.io/courses/redis) which had me reading the spec at [redis.io/topics/protocol](https://redis.io/topics/protocol). 

This sentence didn't make sense to me, so I've edited in what I think is the intended meaning. 