### PR TITLE
Reserving field names in the uri specification grammar

### DIFF
--- a/uri/redis.txt
+++ b/uri/redis.txt
@@ -98,6 +98,16 @@ Scheme semantics:
   The semantics of "query" URI field key-value pairs other than those
   previously mentioned are implementation-defined.
 
+Reserved URI fields:
+
+  The following field names are reserved within the URI context.
+These are expressed using RGC 5234 ABNF, and are reserved as follows:
+
+  protocol       = DIGIT / "."
+                 ; this is optional, corresponding to the version of
+                 ; the RESP protocol requested.
+                 ; the digits 0-9, and a period
+
 Encoding considerations:
   Unknown, use with care.
 

--- a/uri/rediss.txt
+++ b/uri/rediss.txt
@@ -58,6 +58,16 @@ Scheme semantics:
   semantics as the redis: scheme.  See the IANA registration for the
   redis: scheme for details.
 
+Reserved URI fields:
+
+  The following field names are reserved within the URI context.
+These are expressed using RGC 5234 ABNF, and are reserved as follows:
+
+  protocol       = DIGIT / "."
+                 ; this is optional, corresponding to the version of
+                 ; the RESP protocol requested.
+                 ; the digits 0-9, and a period
+
 Encoding considerations:
   Unknown, use with care.
 


### PR DESCRIPTION
This change aims to help solidify the URI grammar used in communicating redis connection URLs.  Specifically, this covers reserving fields, creating the first reserved field *protocol*.

The purpose of this change is to make it possible for Redis clients to align on how they might configure themselves, to request a specific version of the RESP protocol. This encourages no **server-side** change of behaviour, and serves only to ensure that Redis client configurations can begin to standardize on common field names.